### PR TITLE
Change recommended view path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ repository:
 
 ```yaml
 spack:
-  view: view
+  view: /opt/view
   specs:
   - python@3.11
 


### PR DESCRIPTION
Installing the spack view to `view` (i.e., `${{github.workspace}}/view`) puts it inside the source checkout directory. When using CMake and the [CMAKE_INSTALL_RPATH_USE_LINK_PATH](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_RPATH_USE_LINK_PATH.html) option, this means the view gets *removed* from the rpath on installation.

Installing the view to `/opt` fixes this issue, so let's recommend to users that they also put the view outside the source tree.