### PR TITLE
Fix spack-bash example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
       run: spack -e . install
 
     - name: Run
-      shell: spack-bash
+      shell: spack-bash {0}
       run: |
         spack env activate .
         python3 -c 'print("hello world")'


### PR DESCRIPTION
Without the ` {0}` I got:
```
Error: Invalid shell option. Shell must be a valid built-in (bash, sh, cmd, powershell, pwsh) or a format string containing '{0}'
```